### PR TITLE
No more Entities in Shared project 

### DIFF
--- a/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
+++ b/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
@@ -280,7 +280,8 @@ namespace PlanningPoker.Services.Tests
 
         private HashSet<Item> CreateItemEntityHashSet()
         {
-            return new HashSet<Item> {
+            return new HashSet<Item>
+            {
                 new Item
                 {
                     Id = 1,
@@ -300,7 +301,8 @@ namespace PlanningPoker.Services.Tests
 
         private HashSet<ItemDTO> CreateItemDTOHashSet()
         {
-            return new HashSet<ItemDTO> {
+            return new HashSet<ItemDTO>
+            {
                 new ItemDTO
                 {
                     Id = 1,
@@ -327,7 +329,7 @@ namespace PlanningPoker.Services.Tests
                     Id = 1,
                     Votes = new HashSet<VoteDTO>
                     {
-                        new VoteDTO { Id = 1, UserId = 1, Estimate = 5}
+                        new VoteDTO { Id = 1, UserId = 1, Estimate = 5 }
                     }
                 }
             };
@@ -342,7 +344,7 @@ namespace PlanningPoker.Services.Tests
                     Id = 1,
                     Votes = new HashSet<Vote>
                     {
-                        new Vote { Id = 1, UserId = 1, Estimate = 5}
+                        new Vote { Id = 1, UserId = 1, Estimate = 5 }
                     }
                 }
             };

--- a/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
+++ b/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
@@ -11,81 +11,19 @@ namespace PlanningPoker.Services.Tests
         [Fact]
         public void ToItemEntities_returns_Collection_of_equal_size()
         {
-            var dtos = new HashSet<ItemDTO> {
-                new ItemDTO
-                {
-                    Id = 1,
-                    Title = "item 1",
-                    Description = "item 1",
-                    Rounds = new HashSet<RoundDTO>()
-                },
-                new ItemDTO
-                {
-                    Id = 2,
-                    Title = "item 2",
-                    Description = "item 2",
-                    Rounds = new HashSet<RoundDTO>()
-                }
-            };
-
-            var entities = new HashSet<Item> {
-                new Item
-                {
-                    Id = 1,
-                    Title = "item 1",
-                    Description = "item 1",
-                    Rounds = new HashSet<Round>()
-                },
-                new Item
-                {
-                    Id = 2,
-                    Title = "item 2",
-                    Description = "item 2",
-                    Rounds = new HashSet<Round>()
-                }
-            };
-
+            var dtos = this.CreateItemDTOHashSet();
+            
             var result = CollectionHandler.ToItemEntities(dtos);
 
-            Assert.Equal(entities.Count, result.Count);
+            Assert.Equal(dtos.Count, result.Count);
         }
 
         [Fact]
         public void ToItemEntities_returns_Collection_of_correct_entities()
         {
-            var dtos = new HashSet<ItemDTO> {
-                new ItemDTO
-                {
-                    Id = 1,
-                    Title = "item 1",
-                    Description = "item 1",
-                    Rounds = new HashSet<RoundDTO>()
-                },
-                new ItemDTO
-                {
-                    Id = 2,
-                    Title = "item 2",
-                    Description = "item 2",
-                    Rounds = new HashSet<RoundDTO>()
-                }
-            };
+            var dtos = this.CreateItemDTOHashSet();
 
-            var entities = new HashSet<Item> {
-                new Item
-                {
-                    Id = 1,
-                    Title = "item 1",
-                    Description = "item 1",
-                    Rounds = new HashSet<Round>()
-                },
-                new Item
-                {
-                    Id = 2,
-                    Title = "item 2",
-                    Description = "item 2",
-                    Rounds = new HashSet<Round>()
-                }
-            };
+            var entities = this.CreateItemEntityHashSet();
 
             var result = CollectionHandler.ToItemEntities(dtos);
 
@@ -99,81 +37,19 @@ namespace PlanningPoker.Services.Tests
         [Fact]
         public void ToItemDtos_returns_Collection_of_equal_size()
         {
-            var dtos = new HashSet<ItemDTO> {
-                new ItemDTO
-                {
-                    Id = 1,
-                    Title = "item 1",
-                    Description = "item 1",
-                    Rounds = new HashSet<RoundDTO>()
-                },
-                new ItemDTO
-                {
-                    Id = 2,
-                    Title = "item 2",
-                    Description = "item 2",
-                    Rounds = new HashSet<RoundDTO>()
-                }
-            };
-
-            var entities = new HashSet<Item> {
-                new Item
-                {
-                    Id = 1,
-                    Title = "item 1",
-                    Description = "item 1",
-                    Rounds = new HashSet<Round>()
-                },
-                new Item
-                {
-                    Id = 2,
-                    Title = "item 2",
-                    Description = "item 2",
-                    Rounds = new HashSet<Round>()
-                }
-            };
+           var entities = this.CreateItemEntityHashSet();
 
             var result = CollectionHandler.ToItemDtos(entities);
 
-            Assert.Equal(dtos.Count, result.Count);
+            Assert.Equal(entities.Count, result.Count);
         }
 
         [Fact]
         public void ToItemDtos_returns_Collection_of_correct_dtos()
         {
-            var dtos = new HashSet<ItemDTO> {
-                new ItemDTO
-                {
-                    Id = 1,
-                    Title = "item 1",
-                    Description = "item 1",
-                    Rounds = new HashSet<RoundDTO>()
-                },
-                new ItemDTO
-                {
-                    Id = 2,
-                    Title = "item 2",
-                    Description = "item 2",
-                    Rounds = new HashSet<RoundDTO>()
-                }
-            };
+            var dtos = this.CreateItemDTOHashSet();
 
-            var entities = new HashSet<Item> {
-                new Item
-                {
-                    Id = 1,
-                    Title = "item 1",
-                    Description = "item 1",
-                    Rounds = new HashSet<Round>()
-                },
-                new Item
-                {
-                    Id = 2,
-                    Title = "item 2",
-                    Description = "item 2",
-                    Rounds = new HashSet<Round>()
-                }
-            };
+            var entities = this.CreateItemEntityHashSet();
 
             var result = CollectionHandler.ToItemDtos(entities);
 
@@ -184,6 +60,135 @@ namespace PlanningPoker.Services.Tests
             Assert.Equal("item 1", firstItem.Description);
         }
 
+        [Fact]
+        public void ToRoundEntities_returns_correct_size()
+        {
+            var dtos = this.CreateRoundDTOHashSet();
 
+            var result = CollectionHandler.ToRoundEntities(dtos);
+
+            Assert.Equal(dtos.Count, result.Count);
+        }
+
+        [Fact]
+        public void ToRoundEntities_returns_correct_entities()
+        {
+            var dtos = this.CreateRoundDTOHashSet();
+
+            var entities = this.CreateRoundEntityHashSet();
+
+            var entityVote = entities.ToList().FirstOrDefault().Votes.ToList().FirstOrDefault();
+
+            var result = CollectionHandler.ToRoundEntities(dtos);
+
+            var firstRound = result.ToList().FirstOrDefault();
+
+            var roundVote = firstRound.Votes.ToList().FirstOrDefault();
+
+            Assert.Equal(1, firstRound.Id);
+            Assert.Equal(entityVote.Estimate, roundVote.Estimate);
+            Assert.Equal(entityVote.UserId, roundVote.UserId);
+        }
+
+        [Fact]
+        public void ToRoundDtos_returns_correct_size()
+        {
+            var entities = this.CreateRoundEntityHashSet();
+
+            var result = CollectionHandler.ToRoundDtos(entities);
+
+            Assert.Equal(entities.Count, result.Count);
+        }
+
+
+        [Fact]
+        public void ToRoundDtos_returns_correct_dtos()
+        {
+            var dtos = this.CreateRoundDTOHashSet();
+
+            var dtoVote = dtos.ToList().FirstOrDefault().Votes.ToList().FirstOrDefault();
+
+            var entities = this.CreateRoundEntityHashSet();
+
+            var result = CollectionHandler.ToRoundDtos(entities);
+
+            var firstRound = result.ToList().FirstOrDefault();
+
+            var roundVote = firstRound.Votes.ToList().FirstOrDefault();
+
+            Assert.Equal(1, firstRound.Id);
+            Assert.Equal(dtoVote.Estimate, roundVote.Estimate);
+            Assert.Equal(dtoVote.UserId, roundVote.UserId);
+        }
+
+        private HashSet<Item> CreateItemEntityHashSet()
+        {
+            return new HashSet<Item> {
+                new Item
+                {
+                    Id = 1,
+                    Title = "item 1",
+                    Description = "item 1",
+                    Rounds = new HashSet<Round>()
+                },
+                new Item
+                {
+                    Id = 2,
+                    Title = "item 2",
+                    Description = "item 2",
+                    Rounds = new HashSet<Round>()
+                }
+            };
+        }
+
+        private HashSet<ItemDTO> CreateItemDTOHashSet()
+        {
+            return new HashSet<ItemDTO> {
+                new ItemDTO
+                {
+                    Id = 1,
+                    Title = "item 1",
+                    Description = "item 1",
+                    Rounds = new HashSet<RoundDTO>()
+                },
+                new ItemDTO
+                {
+                    Id = 2,
+                    Title = "item 2",
+                    Description = "item 2",
+                    Rounds = new HashSet<RoundDTO>()
+                }
+            };
+        }
+
+        private HashSet<RoundDTO> CreateRoundDTOHashSet()
+        {
+            return new HashSet<RoundDTO>
+            {
+                new RoundDTO
+                {
+                    Id = 1,
+                    Votes = new HashSet<VoteDTO>
+                    {
+                        new VoteDTO { Id = 1, UserId = 1, Estimate = 5}
+                    }
+                }
+            };
+        }
+
+        private HashSet<Round> CreateRoundEntityHashSet()
+        {
+            return new HashSet<Round>
+            {
+                new Round
+                {
+                    Id = 1,
+                    Votes = new HashSet<Vote>
+                    {
+                        new Vote { Id = 1, UserId = 1, Estimate = 5}
+                    }
+                }
+            };
+        }
     }
 }

--- a/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
+++ b/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
@@ -1,0 +1,13 @@
+namespace PlanningPoker.Services.Tests
+{
+    using Xunit;
+
+    public class CollectionHandlerTests
+    {
+        [Fact]
+        public void ToItemEntities_returns_Collection_of_entities()
+        {
+
+        }        
+    }
+}

--- a/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
+++ b/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
@@ -12,7 +12,7 @@ namespace PlanningPoker.Services.Tests
         public void ToItemEntities_returns_Collection_of_equal_size()
         {
             var dtos = this.CreateItemDTOHashSet();
-            
+
             var result = CollectionHandler.ToItemEntities(dtos);
 
             Assert.Equal(dtos.Count, result.Count);
@@ -100,7 +100,6 @@ namespace PlanningPoker.Services.Tests
             Assert.Equal(entities.Count, result.Count);
         }
 
-
         [Fact]
         public void ToRoundDtos_returns_correct_dtos()
         {
@@ -119,6 +118,112 @@ namespace PlanningPoker.Services.Tests
             Assert.Equal(1, firstRound.Id);
             Assert.Equal(dtoVote.Estimate, roundVote.Estimate);
             Assert.Equal(dtoVote.UserId, roundVote.UserId);
+        }
+
+        [Fact]
+        public void ToVoteEntities_returns_correct_size()
+        {
+            var dtos = this.CreateVoteDTOHashSet();
+
+            var result = CollectionHandler.ToVoteEntities(dtos);
+
+            Assert.Equal(dtos.Count, result.Count);
+        }
+
+        [Fact]
+        public void ToVoteEntities_returns_correct_entities()
+        {
+            var dtos = this.CreateVoteDTOHashSet();
+
+            var entities = this.CreateVoteEntityHashSet();
+
+            var result = CollectionHandler.ToVoteEntities(dtos);
+
+            var firstVote = result.ToList().FirstOrDefault();
+
+            Assert.Equal(1, firstVote.Id);
+            Assert.Equal(1, firstVote.UserId);
+            Assert.Equal(5, firstVote.Estimate);
+        }
+
+        [Fact]
+        public void ToVoteDtos_returns_correct_size()
+        {
+            var entities = this.CreateVoteEntityHashSet();
+
+            var result = CollectionHandler.ToVoteDtos(entities);
+
+            Assert.Equal(entities.Count, result.Count);
+        }
+
+        [Fact]
+        public void ToVoteDtos_returns_correct_dtos()
+        {
+            var dtos = this.CreateVoteDTOHashSet();
+
+            var entities = this.CreateVoteEntityHashSet();
+
+            var result = CollectionHandler.ToVoteDtos(entities);
+
+            var firstVote = result.ToList().FirstOrDefault();
+
+            Assert.Equal(1, firstVote.Id);
+            Assert.Equal(1, firstVote.UserId);
+            Assert.Equal(5, firstVote.Estimate);
+        }
+
+        [Fact]
+        public void ToUserEntities_returns_correct_size()
+        {
+            var dtos = this.CreateUserDTOHashSet();
+
+            var result = CollectionHandler.ToUserEntities(dtos);
+
+            Assert.Equal(dtos.Count, result.Count);
+        }
+
+        [Fact]
+        public void ToUserEntities_returns_correct_entities()
+        {
+            var dtos = this.CreateUserDTOHashSet();
+
+            var entities = this.CreateUserEntityHashSet();
+
+            var result = CollectionHandler.ToUserEntities(dtos);
+
+            var firstUser = result.ToList().FirstOrDefault();
+
+            Assert.Equal(1, firstUser.Id);
+            Assert.True(firstUser.IsHost);
+            Assert.Equal("dummy@user.com", firstUser.Email);
+            Assert.Equal("Dummy", firstUser.Nickname);
+        }
+
+        [Fact]
+        public void ToUserDtos_returns_correct_size()
+        {
+            var entities = this.CreateUserEntityHashSet();
+
+            var result = CollectionHandler.ToUserDtos(entities);
+
+            Assert.Equal(entities.Count, result.Count);
+        }
+
+        [Fact]
+        public void ToUserDtos_returns_correct_dtos()
+        {
+            var dtos = this.CreateUserDTOHashSet();
+
+            var entities = this.CreateUserEntityHashSet();
+
+            var result = CollectionHandler.ToUserDtos(entities);
+
+            var firstUser = result.ToList().FirstOrDefault();
+
+            Assert.Equal(1, firstUser.Id);
+            Assert.True(firstUser.IsHost);
+            Assert.Equal("dummy@user.com", firstUser.Email);
+            Assert.Equal("Dummy", firstUser.Nickname);
         }
 
         private HashSet<Item> CreateItemEntityHashSet()
@@ -187,6 +292,60 @@ namespace PlanningPoker.Services.Tests
                     {
                         new Vote { Id = 1, UserId = 1, Estimate = 5}
                     }
+                }
+            };
+        }
+
+        private HashSet<VoteDTO> CreateVoteDTOHashSet()
+        {
+            return new HashSet<VoteDTO>
+            {
+                new VoteDTO
+                {
+                    Id = 1,
+                    UserId = 1,
+                    Estimate = 5
+                }
+            };
+        }
+
+        private HashSet<Vote> CreateVoteEntityHashSet()
+        {
+            return new HashSet<Vote>
+            {
+                new Vote
+                {
+                    Id = 1,
+                    UserId = 1,
+                    Estimate = 5
+                }
+            };
+        }
+
+        private HashSet<UserDTO> CreateUserDTOHashSet()
+        {
+            return new HashSet<UserDTO>
+            {
+                new UserDTO
+                {
+                    Id = 1,
+                    IsHost = true,
+                    Email = "dummy@user.com",
+                    Nickname = "Dummy"
+                }
+            };
+        }
+
+        private HashSet<User> CreateUserEntityHashSet()
+        {
+            return new HashSet<User>
+            {
+                new User
+                {
+                    Id = 1,
+                    IsHost = true,
+                    Email = "dummy@user.com",
+                    Nickname = "Dummy"
                 }
             };
         }

--- a/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
+++ b/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
@@ -92,8 +92,98 @@ namespace PlanningPoker.Services.Tests
             var firstItem = result.ToList().FirstOrDefault();
 
             Assert.Equal(1, firstItem.Id);
+            Assert.Equal("item 1", firstItem.Title);
+            Assert.Equal("item 1", firstItem.Description);
+        }
+
+        [Fact]
+        public void ToItemDtos_returns_Collection_of_equal_size()
+        {
+            var dtos = new HashSet<ItemDTO> {
+                new ItemDTO
+                {
+                    Id = 1,
+                    Title = "item 1",
+                    Description = "item 1",
+                    Rounds = new HashSet<RoundDTO>()
+                },
+                new ItemDTO
+                {
+                    Id = 2,
+                    Title = "item 2",
+                    Description = "item 2",
+                    Rounds = new HashSet<RoundDTO>()
+                }
+            };
+
+            var entities = new HashSet<Item> {
+                new Item
+                {
+                    Id = 1,
+                    Title = "item 1",
+                    Description = "item 1",
+                    Rounds = new HashSet<Round>()
+                },
+                new Item
+                {
+                    Id = 2,
+                    Title = "item 2",
+                    Description = "item 2",
+                    Rounds = new HashSet<Round>()
+                }
+            };
+
+            var result = CollectionHandler.ToItemDtos(entities);
+
+            Assert.Equal(dtos.Count, result.Count);
+        }
+
+        [Fact]
+        public void ToItemDtos_returns_Collection_of_correct_dtos()
+        {
+            var dtos = new HashSet<ItemDTO> {
+                new ItemDTO
+                {
+                    Id = 1,
+                    Title = "item 1",
+                    Description = "item 1",
+                    Rounds = new HashSet<RoundDTO>()
+                },
+                new ItemDTO
+                {
+                    Id = 2,
+                    Title = "item 2",
+                    Description = "item 2",
+                    Rounds = new HashSet<RoundDTO>()
+                }
+            };
+
+            var entities = new HashSet<Item> {
+                new Item
+                {
+                    Id = 1,
+                    Title = "item 1",
+                    Description = "item 1",
+                    Rounds = new HashSet<Round>()
+                },
+                new Item
+                {
+                    Id = 2,
+                    Title = "item 2",
+                    Description = "item 2",
+                    Rounds = new HashSet<Round>()
+                }
+            };
+
+            var result = CollectionHandler.ToItemDtos(entities);
+
+            var firstItem = result.ToList().FirstOrDefault();
+
+            Assert.Equal(1, firstItem.Id);
             Assert.Equal("item 2", firstItem.Title);
             Assert.Equal("item 2", firstItem.Description);
         }
+
+
     }
 }

--- a/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
+++ b/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
@@ -226,6 +226,58 @@ namespace PlanningPoker.Services.Tests
             Assert.Equal("Dummy", firstUser.Nickname);
         }
 
+        [Fact]
+        public void ToItemEstimateEntities_returns_correct_size()
+        {
+            var dtos = this.CreateItemEstimateDTOHashSet();
+
+            var result = CollectionHandler.ToItemEstimateEntities(dtos);
+
+            Assert.Equal(dtos.Count, result.Count);
+        }
+
+        [Fact]
+        public void ToItemEstimateEntities_returns_correct_entities()
+        {
+            var dtos = this.CreateItemEstimateDTOHashSet();
+
+            var entities = this.CreateItemEstimateEntityHashSet();
+
+            var result = CollectionHandler.ToItemEstimateEntities(dtos);
+
+            var firstItemEstimate = result.ToList().FirstOrDefault();
+
+            Assert.Equal(1, firstItemEstimate.Id);
+            Assert.Equal("Item 1", firstItemEstimate.ItemTitle);
+            Assert.Equal(5, firstItemEstimate.Estimate);
+        }
+
+        [Fact]
+        public void ToItemEstimateDtos_returns_correct_size()
+        {
+            var entities = this.CreateItemEstimateEntityHashSet();
+
+            var result = CollectionHandler.ToItemEstimateDtos(entities);
+
+            Assert.Equal(entities.Count, result.Count);
+        }
+
+        [Fact]
+        public void ToItemEstimateDtos_returns_correct_dtos()
+        {
+            var dtos = this.CreateItemEstimateDTOHashSet();
+
+            var entities = this.CreateItemEstimateEntityHashSet();
+
+            var result = CollectionHandler.ToItemEstimateDtos(entities);
+
+            var firstItemEstimate = result.ToList().FirstOrDefault();
+
+            Assert.Equal(1, firstItemEstimate.Id);
+            Assert.Equal("Item 1", firstItemEstimate.ItemTitle);
+            Assert.Equal(5, firstItemEstimate.Estimate);
+        }
+
         private HashSet<Item> CreateItemEntityHashSet()
         {
             return new HashSet<Item> {
@@ -346,6 +398,32 @@ namespace PlanningPoker.Services.Tests
                     IsHost = true,
                     Email = "dummy@user.com",
                     Nickname = "Dummy"
+                }
+            };
+        }
+
+        private HashSet<ItemEstimateDTO> CreateItemEstimateDTOHashSet()
+        {
+            return new HashSet<ItemEstimateDTO>
+            {
+                new ItemEstimateDTO
+                {
+                    Id = 1,
+                    ItemTitle = "Item 1",
+                    Estimate = 5
+                }
+            };
+        }
+
+        private HashSet<ItemEstimate> CreateItemEstimateEntityHashSet()
+        {
+            return new HashSet<ItemEstimate>
+            {
+                new ItemEstimate
+                {
+                    Id = 1,
+                    ItemTitle = "Item 1",
+                    Estimate = 5
                 }
             };
         }

--- a/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
+++ b/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
@@ -1,13 +1,99 @@
 namespace PlanningPoker.Services.Tests
 {
+    using System.Collections.Generic;
+    using System.Linq;
+    using PlanningPoker.Entities;
+    using PlanningPoker.Shared;
     using Xunit;
 
     public class CollectionHandlerTests
     {
         [Fact]
-        public void ToItemEntities_returns_Collection_of_entities()
+        public void ToItemEntities_returns_Collection_of_equal_size()
         {
+            var dtos = new HashSet<ItemDTO> {
+                new ItemDTO
+                {
+                    Id = 1,
+                    Title = "item 1",
+                    Description = "item 1",
+                    Rounds = new HashSet<RoundDTO>()
+                },
+                new ItemDTO
+                {
+                    Id = 2,
+                    Title = "item 2",
+                    Description = "item 2",
+                    Rounds = new HashSet<RoundDTO>()
+                }
+            };
 
-        }        
+            var entities = new HashSet<Item> {
+                new Item
+                {
+                    Id = 1,
+                    Title = "item 1",
+                    Description = "item 1",
+                    Rounds = new HashSet<Round>()
+                },
+                new Item
+                {
+                    Id = 2,
+                    Title = "item 2",
+                    Description = "item 2",
+                    Rounds = new HashSet<Round>()
+                }
+            };
+
+            var result = CollectionHandler.ToItemEntities(dtos);
+
+            Assert.Equal(entities.Count, result.Count);
+        }
+
+        [Fact]
+        public void ToItemEntities_returns_Collection_of_correct_entities()
+        {
+            var dtos = new HashSet<ItemDTO> {
+                new ItemDTO
+                {
+                    Id = 1,
+                    Title = "item 1",
+                    Description = "item 1",
+                    Rounds = new HashSet<RoundDTO>()
+                },
+                new ItemDTO
+                {
+                    Id = 2,
+                    Title = "item 2",
+                    Description = "item 2",
+                    Rounds = new HashSet<RoundDTO>()
+                }
+            };
+
+            var entities = new HashSet<Item> {
+                new Item
+                {
+                    Id = 1,
+                    Title = "item 1",
+                    Description = "item 1",
+                    Rounds = new HashSet<Round>()
+                },
+                new Item
+                {
+                    Id = 2,
+                    Title = "item 2",
+                    Description = "item 2",
+                    Rounds = new HashSet<Round>()
+                }
+            };
+
+            var result = CollectionHandler.ToItemEntities(dtos);
+
+            var firstItem = result.ToList().FirstOrDefault();
+
+            Assert.Equal(1, firstItem.Id);
+            Assert.Equal("item 2", firstItem.Title);
+            Assert.Equal("item 2", firstItem.Description);
+        }
     }
 }

--- a/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
+++ b/PlanningPoker.Services.Tests/CollectionHandlerTests.cs
@@ -180,8 +180,8 @@ namespace PlanningPoker.Services.Tests
             var firstItem = result.ToList().FirstOrDefault();
 
             Assert.Equal(1, firstItem.Id);
-            Assert.Equal("item 2", firstItem.Title);
-            Assert.Equal("item 2", firstItem.Description);
+            Assert.Equal("item 1", firstItem.Title);
+            Assert.Equal("item 1", firstItem.Description);
         }
 
 

--- a/PlanningPoker.Services.Tests/SessionRepositoryTests.cs
+++ b/PlanningPoker.Services.Tests/SessionRepositoryTests.cs
@@ -187,7 +187,7 @@ namespace PlanningPoker.Services.Tests
             return new Session
             {
                 SessionKey = "A1B2C3D",
-                Items = new List<Item> { new Item { Title = "item 1" }, new Item { Title = "item 2" } },
+                Items = new List<Item> { new Item { Title = "item 1", Rounds = new HashSet<Round>() }, new Item { Title = "item 2", Rounds = new HashSet<Round>() } },
                 Users = new List<User> { new User { IsHost = true, Nickname = "user 1" } }
             };
         }
@@ -197,7 +197,7 @@ namespace PlanningPoker.Services.Tests
             return new SessionCreateUpdateDTO
             {
                 SessionKey = "A1B2C3D",
-                Items = new List<ItemDTO> { new ItemDTO { Title = "item 1" }, new ItemDTO { Title = "item 2" } },
+                Items = new List<ItemDTO> { new ItemDTO { Title = "item 1", Rounds = new HashSet<RoundDTO>() }, new ItemDTO { Title = "item 2", Rounds = new HashSet<RoundDTO>() } },
                 Users = new List<UserDTO> { new UserDTO { IsHost = true, Nickname = "user 1" } }
             };
         }

--- a/PlanningPoker.Services.Tests/SessionRepositoryTests.cs
+++ b/PlanningPoker.Services.Tests/SessionRepositoryTests.cs
@@ -197,8 +197,8 @@ namespace PlanningPoker.Services.Tests
             return new SessionCreateUpdateDTO
             {
                 SessionKey = "A1B2C3D",
-                Items = new List<Item> { new Item { Title = "item 1" }, new Item { Title = "item 2" } },
-                Users = new List<User> { new User { IsHost = true, Nickname = "user 1" } }
+                Items = new List<ItemDTO> { new ItemDTO { Title = "item 1" }, new ItemDTO { Title = "item 2" } },
+                Users = new List<UserDTO> { new UserDTO { IsHost = true, Nickname = "user 1" } }
             };
         }
     }

--- a/PlanningPoker.Services.Tests/SummaryRepositoryTests.cs
+++ b/PlanningPoker.Services.Tests/SummaryRepositoryTests.cs
@@ -200,10 +200,10 @@ namespace PlanningPoker.Services.Tests
         {
             return new SummaryCreateUpdateDTO
             {
-                ItemEstimates = new List<ItemEstimate>
+                ItemEstimates = new List<ItemEstimateDTO>
                 {
-                    new ItemEstimate { Estimate = 5, ItemTitle = "item 1" },
-                    new ItemEstimate { Estimate = 13, ItemTitle = "item 2" }
+                    new ItemEstimateDTO { Estimate = 5, ItemTitle = "item 1" },
+                    new ItemEstimateDTO { Estimate = 13, ItemTitle = "item 2" }
                 },
 
                 SessionId = 42

--- a/PlanningPoker.Services/CollectionHandler.cs
+++ b/PlanningPoker.Services/CollectionHandler.cs
@@ -10,7 +10,7 @@ namespace PlanningPoker.Services
         public static ICollection<Item> ToItemEntities(ICollection<ItemDTO> dtos)
         {
             var entities = new HashSet<Item>();
-            dtos.Select(i => entities.Add(
+            dtos.ToList().ForEach(i => entities.Add(
                 new Item
                 {
                     Id = i.Id,
@@ -116,6 +116,34 @@ namespace PlanningPoker.Services
                     IsHost = u.IsHost,
                     Email = u.Email,
                     Nickname = u.Nickname
+                }));
+
+            return dtos;
+        }
+
+        public static ICollection<ItemEstimate> ToItemEstimateEntities(ICollection<ItemEstimateDTO> dtos)
+        {
+            var entities = new HashSet<ItemEstimate>();
+            dtos.Select(ie => entities.Add(
+                new ItemEstimate
+                {
+                    Id = ie.Id,
+                    ItemTitle = ie.ItemTitle,
+                    Estimate = ie.Estimate
+                }));
+
+            return entities;
+        }
+
+        public static ICollection<ItemEstimateDTO> ToItemEstimateDtos(ICollection<ItemEstimate> entities)
+        {
+            var dtos = new HashSet<ItemEstimateDTO>();
+            entities.Select(ie => dtos.Add(
+                new ItemEstimateDTO
+                {
+                    Id = ie.Id,
+                    ItemTitle = ie.ItemTitle,
+                    Estimate = ie.Estimate
                 }));
 
             return dtos;

--- a/PlanningPoker.Services/CollectionHandler.cs
+++ b/PlanningPoker.Services/CollectionHandler.cs
@@ -1,0 +1,124 @@
+namespace PlanningPoker.Services
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using PlanningPoker.Entities;
+    using PlanningPoker.Shared;
+
+    public class CollectionHandler
+    {
+        public static ICollection<Item> ToItemEntities(ICollection<ItemDTO> dtos)
+        {
+            var entities = new HashSet<Item>();
+            dtos.Select(i => entities.Add(
+                new Item
+                {
+                    Id = i.Id,
+                    Title = i.Title,
+                    Description = i.Description,
+                    Rounds = ToRoundEntities(i.Rounds),
+                }));
+
+            return entities;
+        }
+
+        public static ICollection<ItemDTO> ToItemDtos(ICollection<Item> entities)
+        {
+            var dtos = new HashSet<ItemDTO>();
+            entities.Select(i => dtos.Add(
+                new ItemDTO
+                {
+                    Id = i.Id,
+                    Title = i.Title,
+                    Description = i.Description,
+                    Rounds = ToRoundDtos(i.Rounds),
+                }));
+
+            return dtos;
+        }
+
+        public static ICollection<Round> ToRoundEntities(ICollection<RoundDTO> dtos)
+        {
+            var entities = new HashSet<Round>();
+            dtos.Select(r => entities.Add(
+                new Round
+                {
+                    Id = r.Id,
+                    Votes = ToVoteEntities(r.Votes)
+                }));
+
+            return entities;
+        }
+
+        public static ICollection<RoundDTO> ToRoundDtos(ICollection<Round> entities)
+        {
+            var dtos = new HashSet<RoundDTO>();
+            entities.Select(r => dtos.Add(
+                new RoundDTO
+                {
+                    Id = r.Id,
+                    Votes = ToVoteDtos(r.Votes)
+                }));
+
+            return dtos;
+        }
+
+        public static ICollection<Vote> ToVoteEntities(ICollection<VoteDTO> dtos)
+        {
+            var entities = new HashSet<Vote>();
+            dtos.Select(v => entities.Add(
+                new Vote
+                {
+                    Id = v.Id,
+                    UserId = v.UserId,
+                    Estimate = v.Estimate
+                }));
+
+            return entities;
+        }
+
+        public static ICollection<VoteDTO> ToVoteDtos(ICollection<Vote> entities)
+        {
+            var dtos = new HashSet<VoteDTO>();
+            entities.Select(v => dtos.Add(
+                new VoteDTO
+                {
+                    Id = v.Id,
+                    UserId = v.UserId,
+                    Estimate = v.Estimate
+                }));
+
+            return dtos;
+        }
+
+        public static ICollection<User> ToUserEntities(ICollection<UserDTO> dtos)
+        {
+            var entities = new HashSet<User>();
+            dtos.Select(u => entities.Add(
+                new User
+                {
+                    Id = u.Id,
+                    IsHost = u.IsHost,
+                    Email = u.Email,
+                    Nickname = u.Nickname
+                }));
+
+            return entities;
+        }
+
+        public static ICollection<UserDTO> ToUserDtos(ICollection<User> entities)
+        {
+            var dtos = new HashSet<UserDTO>();
+            entities.Select(u => dtos.Add(
+                new UserDTO
+                {
+                    Id = u.Id,
+                    IsHost = u.IsHost,
+                    Email = u.Email,
+                    Nickname = u.Nickname
+                }));
+
+            return dtos;
+        }
+    }
+}

--- a/PlanningPoker.Services/CollectionHandler.cs
+++ b/PlanningPoker.Services/CollectionHandler.cs
@@ -25,7 +25,7 @@ namespace PlanningPoker.Services
         public static ICollection<ItemDTO> ToItemDtos(ICollection<Item> entities)
         {
             var dtos = new HashSet<ItemDTO>();
-            entities.Select(i => dtos.Add(
+            entities.ToList().ForEach(i => dtos.Add(
                 new ItemDTO
                 {
                     Id = i.Id,
@@ -40,7 +40,7 @@ namespace PlanningPoker.Services
         public static ICollection<Round> ToRoundEntities(ICollection<RoundDTO> dtos)
         {
             var entities = new HashSet<Round>();
-            dtos.Select(r => entities.Add(
+            dtos.ToList().ForEach(r => entities.Add(
                 new Round
                 {
                     Id = r.Id,
@@ -53,7 +53,7 @@ namespace PlanningPoker.Services
         public static ICollection<RoundDTO> ToRoundDtos(ICollection<Round> entities)
         {
             var dtos = new HashSet<RoundDTO>();
-            entities.Select(r => dtos.Add(
+            entities.ToList().ForEach(r => dtos.Add(
                 new RoundDTO
                 {
                     Id = r.Id,
@@ -66,7 +66,7 @@ namespace PlanningPoker.Services
         public static ICollection<Vote> ToVoteEntities(ICollection<VoteDTO> dtos)
         {
             var entities = new HashSet<Vote>();
-            dtos.Select(v => entities.Add(
+            dtos.ToList().ForEach(v => entities.Add(
                 new Vote
                 {
                     Id = v.Id,
@@ -80,7 +80,7 @@ namespace PlanningPoker.Services
         public static ICollection<VoteDTO> ToVoteDtos(ICollection<Vote> entities)
         {
             var dtos = new HashSet<VoteDTO>();
-            entities.Select(v => dtos.Add(
+            entities.ToList().ForEach(v => dtos.Add(
                 new VoteDTO
                 {
                     Id = v.Id,
@@ -94,7 +94,7 @@ namespace PlanningPoker.Services
         public static ICollection<User> ToUserEntities(ICollection<UserDTO> dtos)
         {
             var entities = new HashSet<User>();
-            dtos.Select(u => entities.Add(
+            dtos.ToList().ForEach(u => entities.Add(
                 new User
                 {
                     Id = u.Id,
@@ -109,7 +109,7 @@ namespace PlanningPoker.Services
         public static ICollection<UserDTO> ToUserDtos(ICollection<User> entities)
         {
             var dtos = new HashSet<UserDTO>();
-            entities.Select(u => dtos.Add(
+            entities.ToList().ForEach(u => dtos.Add(
                 new UserDTO
                 {
                     Id = u.Id,
@@ -124,7 +124,7 @@ namespace PlanningPoker.Services
         public static ICollection<ItemEstimate> ToItemEstimateEntities(ICollection<ItemEstimateDTO> dtos)
         {
             var entities = new HashSet<ItemEstimate>();
-            dtos.Select(ie => entities.Add(
+            dtos.ToList().ForEach(ie => entities.Add(
                 new ItemEstimate
                 {
                     Id = ie.Id,
@@ -138,7 +138,7 @@ namespace PlanningPoker.Services
         public static ICollection<ItemEstimateDTO> ToItemEstimateDtos(ICollection<ItemEstimate> entities)
         {
             var dtos = new HashSet<ItemEstimateDTO>();
-            entities.Select(ie => dtos.Add(
+            entities.ToList().ForEach(ie => dtos.Add(
                 new ItemEstimateDTO
                 {
                     Id = ie.Id,

--- a/PlanningPoker.Services/SessionRepository.cs
+++ b/PlanningPoker.Services/SessionRepository.cs
@@ -19,8 +19,8 @@ namespace PlanningPoker.Services
         {
             var entity = new Session
             {
-                Items = session.Items,
-                Users = session.Users,
+                Items = CollectionHandler.ToItemEntities(session.Items),
+                Users = CollectionHandler.ToUserEntities(session.Users),
                 SessionKey = session.SessionKey
             };
 
@@ -52,8 +52,8 @@ namespace PlanningPoker.Services
                 .Select(s => new SessionDTO
                 {
                     Id = s.Id,
-                    Items = s.Items,
-                    Users = s.Users,
+                    Items = CollectionHandler.ToItemDtos(s.Items),
+                    Users = CollectionHandler.ToUserDtos(s.Users),
                     SessionKey = s.SessionKey
                 });
 
@@ -66,8 +66,8 @@ namespace PlanningPoker.Services
                 .Select(s => new SessionDTO
                 {
                     Id = s.Id,
-                    Items = s.Items,
-                    Users = s.Users,
+                    Items = CollectionHandler.ToItemDtos(s.Items),
+                    Users = CollectionHandler.ToUserDtos(s.Users),
                     SessionKey = s.SessionKey
                 });
 
@@ -83,8 +83,8 @@ namespace PlanningPoker.Services
                 return false;
             }
 
-            entity.Items = session.Items;
-            entity.Users = session.Users;
+            entity.Items = CollectionHandler.ToItemEntities(session.Items);
+            entity.Users = CollectionHandler.ToUserEntities(session.Users);
             entity.SessionKey = session.SessionKey;
 
             this.context.SaveChanges();

--- a/PlanningPoker.Services/SummaryRepository.cs
+++ b/PlanningPoker.Services/SummaryRepository.cs
@@ -19,7 +19,7 @@ namespace PlanningPoker.Services
         {
             var entity = new Summary
             {
-                ItemEstimates = summary.ItemEstimates,
+                ItemEstimates = CollectionHandler.ToItemEstimateEntities(summary.ItemEstimates),
                 SessionId = summary.SessionId
             };
 
@@ -51,7 +51,7 @@ namespace PlanningPoker.Services
                 .Select(s => new SummaryDTO
                 {
                     Id = s.Id,
-                    ItemEstimates = s.ItemEstimates,
+                    ItemEstimates = CollectionHandler.ToItemEstimateDtos(s.ItemEstimates),
                     SessionId = s.SessionId
                 });
 
@@ -64,7 +64,7 @@ namespace PlanningPoker.Services
                 .Select(s => new SummaryDTO
                 {
                     Id = s.Id,
-                    ItemEstimates = s.ItemEstimates,
+                    ItemEstimates = CollectionHandler.ToItemEstimateDtos(s.ItemEstimates),
                     SessionId = s.SessionId
                 });
 
@@ -81,7 +81,7 @@ namespace PlanningPoker.Services
             }
 
             entity.Id = summary.Id;
-            entity.ItemEstimates = summary.ItemEstimates;
+            entity.ItemEstimates = CollectionHandler.ToItemEstimateEntities(summary.ItemEstimates);
             entity.SessionId = summary.SessionId;
 
             this.context.SaveChanges();

--- a/PlanningPoker.Shared/ItemCreateUpdateDTO.cs
+++ b/PlanningPoker.Shared/ItemCreateUpdateDTO.cs
@@ -1,5 +1,6 @@
 namespace PlanningPoker.Shared
 {
+    using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
 
     public class ItemCreateUpdateDTO
@@ -10,5 +11,7 @@ namespace PlanningPoker.Shared
         public string Title { get; set; }
 
         public string Description { get; set; }
+
+        public ICollection<RoundDTO> Rounds { get; set; }
     }
 }

--- a/PlanningPoker.Shared/ItemDTO.cs
+++ b/PlanningPoker.Shared/ItemDTO.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
-
 namespace PlanningPoker.Shared
 {
+    using System.Collections.Generic;
+
     public class ItemDTO
     {
         public int Id { get; set; }

--- a/PlanningPoker.Shared/ItemDTO.cs
+++ b/PlanningPoker.Shared/ItemDTO.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace PlanningPoker.Shared
 {
     public class ItemDTO
@@ -7,5 +9,7 @@ namespace PlanningPoker.Shared
         public string Title { get; set; }
 
         public string Description { get; set; }
+
+        public ICollection<RoundDTO> Rounds { get; set; }
     }
 }

--- a/PlanningPoker.Shared/RoundCreateUpdateDTO.cs
+++ b/PlanningPoker.Shared/RoundCreateUpdateDTO.cs
@@ -1,6 +1,5 @@
 namespace PlanningPoker.Shared
 {
-    using PlanningPoker.Entities;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
 
@@ -9,6 +8,6 @@ namespace PlanningPoker.Shared
         public int Id { get; set; }
 
         [Required]
-        public ICollection<Vote> Votes { get; set; }
+        public ICollection<VoteDTO> Votes { get; set; }
     }
 }

--- a/PlanningPoker.Shared/RoundDTO.cs
+++ b/PlanningPoker.Shared/RoundDTO.cs
@@ -1,12 +1,11 @@
 namespace PlanningPoker.Shared
 {
-    using PlanningPoker.Entities;
     using System.Collections.Generic;
 
     public class RoundDTO
     {
         public int Id { get; set; }
 
-        public ICollection<Vote> Votes { get; set; }
+        public ICollection<VoteDTO> Votes { get; set; }
     }
 }

--- a/PlanningPoker.Shared/SessionCreateUpdateDTO.cs
+++ b/PlanningPoker.Shared/SessionCreateUpdateDTO.cs
@@ -2,7 +2,6 @@ namespace PlanningPoker.Shared
 {
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
-    using PlanningPoker.Entities;
 
     public class SessionCreateUpdateDTO
     {
@@ -13,9 +12,9 @@ namespace PlanningPoker.Shared
         public string SessionKey { get; set; }
 
         [Required]
-        public ICollection<Item> Items { get; set; }
+        public ICollection<ItemDTO> Items { get; set; }
 
         [Required]
-        public ICollection<User> Users { get; set; }
+        public ICollection<UserDTO> Users { get; set; }
     }
 }

--- a/PlanningPoker.Shared/SessionDTO.cs
+++ b/PlanningPoker.Shared/SessionDTO.cs
@@ -1,6 +1,5 @@
 namespace PlanningPoker.Shared
 {
-    using PlanningPoker.Entities;
     using System.Collections.Generic;
 
     public class SessionDTO
@@ -9,8 +8,8 @@ namespace PlanningPoker.Shared
 
         public string SessionKey { get; set; }
 
-        public ICollection<Item> Items { get; set; }
+        public ICollection<ItemDTO> Items { get; set; }
 
-        public ICollection<User> Users { get; set; }
+        public ICollection<UserDTO> Users { get; set; }
     }
 }

--- a/PlanningPoker.Shared/SummaryCreateUpdateDTO.cs
+++ b/PlanningPoker.Shared/SummaryCreateUpdateDTO.cs
@@ -1,6 +1,5 @@
 namespace PlanningPoker.Shared
 {
-    using PlanningPoker.Entities;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
 
@@ -9,7 +8,7 @@ namespace PlanningPoker.Shared
         public int Id { get; set; }
 
         [Required]
-        public ICollection<ItemEstimate> ItemEstimates { get; set; }
+        public ICollection<ItemEstimateDTO> ItemEstimates { get; set; }
 
         [Required]
         public int SessionId { get; set; }

--- a/PlanningPoker.Shared/SummaryDTO.cs
+++ b/PlanningPoker.Shared/SummaryDTO.cs
@@ -1,13 +1,12 @@
 namespace PlanningPoker.Shared
 {
     using System.Collections.Generic;
-    using PlanningPoker.Entities;
 
     public class SummaryDTO
     {
         public int Id { get; set; }
 
-        public ICollection<ItemEstimate> ItemEstimates { get; set; }
+        public ICollection<ItemEstimateDTO> ItemEstimates { get; set; }
 
         public int SessionId { get; set; }
     }


### PR DESCRIPTION
Removed all Entities from all the DTOs in the Shared project.
Created a new class 'CollectionHandler' in the Service project, that is able to convert our DTO collections to Entity collections and vice versa.