### PR TITLE
add build summary to session controller when nextitem is empty 

### DIFF
--- a/PlanningPoker.WebApi/Controllers/SessionController.cs
+++ b/PlanningPoker.WebApi/Controllers/SessionController.cs
@@ -160,6 +160,7 @@ namespace PlanningPoker.WebApi.Controllers
             // TODO: Generate summary when this happens
             if (nextItem == default(ItemDTO))
             {
+                await this.summaryRepository.BuildSummary(session);
                 return this.BadRequest();
             }
 


### PR DESCRIPTION
build summary and then returns a bad request, needs to be handled in front-end when we check for next item and receive a bad request, we go to summary view with session id